### PR TITLE
Upgrade Jinja2 2.10 -> 2.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click==6.7
 Flask==1.0.2
 gunicorn==19.8.1
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.0
 Werkzeug==0.14.1
 atomicwrites==1.3.0


### PR DESCRIPTION
Jinja2 v2.10 has a security vulnerability, while we don't use that particular part of Jinja2 to my knowledge, it is still good practice to be on top of things. 